### PR TITLE
fix: patch MIME boundary prefix

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3,19 +3,21 @@
 var BuildMail = require('buildmail');
 var libmime = require('libmime');
 
+module.exports = Compiler;
+
 // HACK(rtasson): the following couple of lines are hacks to permit us to
 // modify the MIME part boundary prefix without upgrading our nodemailer
 // version to one that supports this natively.
-// The following baseBoundaryPrefix is what nodemailer currently uses:
-// https://github.com/nodemailer/nodemailer/blob/9b5fb94767c6d9ba0851dc487b5b4a2842cdae75/lib/mime-node/index.js#L44
-let baseBoundaryPrefix = '--_NmP';
+// The following baseBoundaryPrefix is what buildmail uses on our old version:
+// https://github.com/nodemailer/buildmail/blob/e38d2d0bdc4d5957e126f90953c0955867a51ce3/src/buildmail.js#L781
+let baseBoundaryPrefix = '----sinikael-?=_';
 
 /**
  * A convenience function to allow us to change the baseBoundaryPrefix.
  *
  * @param {String} prefix The MIME boundary prefix to set
  */
-modules.export.setBaseBoundaryPrefix = function(prefix) {
+module.exports.setBaseBoundaryPrefix = function(prefix) {
   baseBoundaryPrefix = prefix;
 };
 
@@ -28,8 +30,6 @@ BuildMail.prototype._generateBoundary = function() {
   return baseBoundaryPrefix + this._nodeId + '-' + this.rootNode.baseBoundary;
 };
 // end hack
-
-module.exports = Compiler;
 
 /**
  * Creates the object for composing a BuildMail instance out from the mail options

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3,6 +3,32 @@
 var BuildMail = require('buildmail');
 var libmime = require('libmime');
 
+// HACK(rtasson): the following couple of lines are hacks to permit us to
+// modify the MIME part boundary prefix without upgrading our nodemailer
+// version to one that supports this natively.
+// The following baseBoundaryPrefix is what nodemailer currently uses:
+// https://github.com/nodemailer/nodemailer/blob/9b5fb94767c6d9ba0851dc487b5b4a2842cdae75/lib/mime-node/index.js#L44
+let baseBoundaryPrefix = '--_NmP';
+
+/**
+ * A convenience function to allow us to change the baseBoundaryPrefix.
+ *
+ * @param {String} prefix The MIME boundary prefix to set
+ */
+modules.export.setBaseBoundaryPrefix = function(prefix) {
+  baseBoundaryPrefix = prefix;
+};
+
+/*
+ * Generates a multipart boundary value. This is a patch of the buildmail code.
+ *
+ * @return {String} boundary value
+ */
+BuildMail.prototype._generateBoundary = function() {
+  return baseBoundaryPrefix + this._nodeId + '-' + this.rootNode.baseBoundary;
+};
+// end hack
+
 module.exports = Compiler;
 
 /**

--- a/src/nodemailer.js
+++ b/src/nodemailer.js
@@ -9,6 +9,9 @@ var packageData = require('../package.json');
 var fs = require('fs');
 var hyperquest = require('hyperquest');
 
+// Export setBaseBoundaryPrefix
+module.exports.setBaseBoundaryPrefix = Compiler.setBaseBoundaryPrefix;
+
 // Export createTransport method
 module.exports.createTransport = function(transporter) {
     transporter = transporter || directTransport({


### PR DESCRIPTION
This PR allows us to modify the prefix Nodemailer uses to generate MIME boundary strings without upgrading Nodemailer. I worked with @shils on this a smidge, but would appreciate any feedback.

I think the biggest risk here is that this monkeypatched snippet of code doesn't get used every single time. In reading through `buildmail`, it doesn't look like the constructor does anything funky here, but I could have missed something. The net result of that would be improperly constructed (or de-structured) emails.