### PR TITLE
fix: correct package.json version ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixmaxhq/nodemailer",
-  "version": "1.4.1",
+  "version": "1.4.2-beta",
   "description": "Easy as cake e-mail sending from your Node.js applications",
   "main": "src/nodemailer.js",
   "scripts": {
@@ -10,15 +10,7 @@
     "type": "git",
     "url": "git://github.com/mixmaxhq/nodemailer.git"
   },
-  "keywords": [
-    "e-mail",
-    "mime",
-    "email",
-    "mail",
-    "sendmail",
-    "ses",
-    "smtp"
-  ],
+  "keywords": ["e-mail", "mime", "email", "mail", "sendmail", "ses", "smtp"],
   "author": "Andris Reinman",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This was omitted from the earlier release and is necessary to properly test a staging deploy for now.